### PR TITLE
Increase exec maxBuffer option, from default (200KB) to 500KB

### DIFF
--- a/index.js
+++ b/index.js
@@ -158,6 +158,10 @@ Worker.prototype.processRequest = function (req) {
 
   console.log('[%s] Received valid hook for app %s', new Date().toISOString(), targetName);
 
+  var execOptions = {
+    cwd: targetApp.cwd,
+    maxBuffer: 1024 * 500
+  };
   async.series([
     // resolving cwd
     function (callback) {
@@ -187,7 +191,7 @@ Worker.prototype.processRequest = function (req) {
     function (callback) {
       if (!targetApp.prehook) return callback();
 
-      exec(targetApp.prehook, { cwd: targetApp.cwd }, function (err, stdout, stderr) {
+      exec(targetApp.prehook, execOptions, function (err, stdout, stderr) {
         if (err) return callback(err);
 
         console.log('[%s] Pre-hook command has been successfuly executed for app %s', new Date().toISOString(), targetName);
@@ -210,7 +214,7 @@ Worker.prototype.processRequest = function (req) {
       if (!targetApp.posthook) return callback();
 
       // execute the actual command in the cwd of the application
-      exec(targetApp.posthook, { cwd: targetApp.cwd }, function (err, stdout, stderr) {
+      exec(targetApp.posthook, execOptions, function (err, stdout, stderr) {
         if (err) return callback(err);
 
         console.log('[%s] Posthook command has been successfuly executed for app %s', new Date().toISOString(), targetName);


### PR DESCRIPTION
I use pm2-githook to add CI to a project made with webpack. On every push we need to rebuild the entire project, and by default webpack shows in the console all the information. Also we have a custom install script which shows a lot of info in the console.

We solved the issue redirecting output to null (&> /dev/null) but I think there is the need to increase this limit. Also we added `&> /dev/null` to the postscript line but it didn't work, I needed to add it to some lines inside the .sh script. 

I opened this PR to discuss this buffer increment, if this is something this library needs to change or maybe only with the workaround (&> /dev/null) is enough.

Thanks!