### PR TITLE
Replace exec with spawn

### DIFF
--- a/index.js
+++ b/index.js
@@ -112,7 +112,7 @@ Worker.prototype.processRequest = function (req) {
     env: process.env,
     shell: true
   };
-  var steps = {
+  var phases = {
     resolveCWD: function resolveCWD(cb) {
       // if cwd is provided, we expect that it isnt a pm2 app
       if (targetApp.cwd) return cb();
@@ -151,14 +151,13 @@ Worker.prototype.processRequest = function (req) {
           logCallback(cb, '[%s] Posthook command has been successfuly executed for app %s', new Date().toISOString(), targetName));
     }
   };
-  async.series([
-    steps.resolveCWD, steps.pullTheApplication, steps.preHook, steps.reloadApplication, steps.postHook
-  ], function (err, results) {
-    if (err) {
-      console.log('[%s] An error has occuring while processing app %s', new Date().toISOString(), targetName);
-      console.error(err);
-    }
-  });
+  async.series(Object.keys(phases).map(function(k){ return phases[k]; }),
+    function (err, results) {
+      if (err) {
+        console.log('[%s] An error has occuring while processing app %s', new Date().toISOString(), targetName);
+        console.error(err);
+      }
+    });
 };
 
 /**

--- a/index.js
+++ b/index.js
@@ -138,7 +138,7 @@ Worker.prototype.processRequest = function (req) {
           logCallback(cb, '[%s] Prehook command has been successfuly executed for app %s', new Date().toISOString(), targetName));
     },
     reloadApplication: function reloadApplication(cb) {
-      if (!targetApp.prehook) return cb();
+      if (!targetApp.nopm2) return cb();
 
       spawnAsExec(targetApp.prehook, execOptions,
           logCallback(cb, '[%s] Successfuly reloaded application %s', new Date().toISOString(), targetName));

--- a/index.js
+++ b/index.js
@@ -8,12 +8,15 @@ var http = require('http');
 var crypto = require('crypto');
 var pmx = require('pmx');
 var pm2 = require('pm2');
+var util = require('util');
 var exec = require('child_process').exec;
 var async = require('async');
 var vizion = require('vizion');
 var ipaddr = require('ipaddr.js');
 
-// init pmx module
+/**
+ * Init pmx module
+ */
 pmx.initModule({}, function (err, conf) {
   pm2.connect(function (err2) {
     if (err || err2) {
@@ -25,6 +28,13 @@ pmx.initModule({}, function (err, conf) {
   });
 });
 
+/**
+ * Constructor of our worker
+ *
+ * @param {object} opts The options
+ * @returns {Worker} The instance of our worker
+ * @constructor
+ */
 var Worker = function (opts) {
   if (!(this instanceof Worker)) {
     return new Worker(opts);
@@ -42,6 +52,13 @@ var Worker = function (opts) {
   return this;
 };
 
+/**
+ * Main function for http server
+ *
+ * @param req The Request
+ * @param res The Response
+ * @private
+ */
 Worker.prototype._handleHttp = function (req, res) {
   var self = this;
 
@@ -70,90 +87,22 @@ Worker.prototype._handleHttp = function (req, res) {
   });
 };
 
+/**
+ * Main function of the module
+ *
+ * @param req The Request of the call
+ */
 Worker.prototype.processRequest = function (req) {
-  var targetName = req.url.split('/').pop();
+  var targetName = reqToAppName(req);
   if (targetName.length === 0) return;
 
   var targetApp = this.apps[targetName];
   if (!targetApp) return;
 
-  // validate the request
-  switch (targetApp.service) {
-    case 'gitlab': {
-      if (!req.headers['x-gitlab-token']) {
-        return console.log('[%s] Received invalid request for app %s (no headers found)', new Date().toISOString(), targetName);
-      }
-
-      if (req.headers['x-gitlab-token'] !== targetApp.secret) {
-        return console.log('[%s] Received invalid request for app %s (not matching secret)', new Date().toISOString(), targetName);
-      }
-      break;
-    }
-    case 'jenkins': {
-      // ip must match the secret
-      if (req.ip.indexOf(targetApp.secret) < 0) {
-        return console.log('[%s] Received request from %s for app %s but ip configured was %s', new Date().toISOString(), req.ip, targetName, targetApp.secret);
-      }
-
-      var body = JSON.parse(req.body);
-      if (body.build.status !== 'SUCCESS') {
-        return console.log('[%s] Received valid hook but with failure build for app %s', new Date().toISOString(), targetName);
-      }
-      if (targetApp.branch && body.build.scm.branch.indexOf(targetApp.branch) < 0) {
-        return console.log('[%s] Received valid hook but with a branch %s than configured for app %s', new Date().toISOString(), body.build.scm.branch, targetName);
-      }
-      break;
-    }
-    case 'droneci': {
-      // Authorization header must match configured secret
-      if (!req.headers['Authorization']) {
-        return console.log('[%s] Received invalid request for app %s (no headers found)', new Date().toISOString(), targetName);
-      }
-      if (req.headers['Authorization'] !== targetApp.secret) {
-        return console.log('[%s] Received request from %s for app %s but incorrect secret', new Date().toISOString(), req.ip, targetName);
-      }
-
-      var data = JSON.parse(req.body);
-      if (data.build.status !== 'SUCCESS') {
-        return console.log('[%s] Received valid hook but with failure build for app %s', new Date().toISOString(), targetName);
-      }
-      if (targetApp.branch && data.build.branch.indexOf(targetApp.branch) < 0) {
-        return console.log('[%s] Received valid hook but with a branch %s than configured for app %s', new Date().toISOString(), data.build.branch, targetName);
-      }
-      break;
-    }
-    case 'bitbucket': {
-      var tmp = JSON.parse(req.body);
-      var ip = targetApp.secret || '104.192.143.0/24';
-      var configured = ipaddr.parseCIDR(ip);
-
-      if (!tmp.match(configured)) {
-        return console.log('[%s] Received request from %s for app %s but ip configured was %s', new Date().toISOString(), req.ip, targetName, ip);
-      }
-      if (!body.push) {
-        return console.log("[%s] Received valid hook but without 'push' data for app %s", new Date().toISOString(), targetName);
-      }
-      if (targetApp.branch && tmp.push.changes[0] && tmp.push.changes[0].new.name.indexOf(targetApp.branch) < 0) {
-        return console.log('[%s] Received valid hook but with a branch %s than configured for app %s', new Date().toISOString(), tmp.push.changes[0].new.name, targetName);
-      }
-      break;
-    }
-    case 'github' :
-    default: {
-      if (!req.headers['x-github-event'] || !req.headers['x-hub-signature']) {
-        return console.log('[%s] Received invalid request for app %s (no headers found)', new Date().toISOString(), targetName);
-      }
-
-      // compute hash of body with secret, github should send this to verify authenticity
-      var temp = crypto.createHmac('sha1', targetApp.secret);
-      temp.update(req.body, 'utf-8');
-      var hash = temp.digest('hex');
-
-      if ('sha1=' + hash !== req.headers['x-hub-signature']) {
-        return console.log('[%s] Received invalid request for app %s', new Date().toISOString(), targetName);
-      }
-      break;
-    }
+  var error = this.checkRequest(targetApp, req);
+  if (error) {
+    console.log(error);
+    return;
   }
 
   console.log('[%s] Received valid hook for app %s', new Date().toISOString(), targetName);
@@ -162,65 +111,47 @@ Worker.prototype.processRequest = function (req) {
     cwd: targetApp.cwd,
     maxBuffer: 1024 * 500
   };
-  async.series([
-    // resolving cwd
-    function (callback) {
+  var steps = {
+    resolveCWD: function resolveCWD(cb) {
       // if cwd is provided, we expect that it isnt a pm2 app
-      if (targetApp.cwd) return callback();
+      if (targetApp.cwd) return cb();
 
       // try to get the cwd to execute it correctly
       pm2.describe(targetName, function (err, apps) {
-        if (err || !apps || apps.length === 0) return callback(err || new Error('Application not found'));
+        if (err || !apps || apps.length === 0) return cb(err || new Error('Application not found'));
 
         // execute the actual command in the cwd of the application
         targetApp.cwd = apps[0].pm_cwd ? apps[0].pm_cwd : apps[0].pm2_env.pm_cwd;
-        return callback();
+        return cb();
       });
     },
-    // Pull the application
-    function (callback) {
+    pullTheApplication: function pullTheApplication(cb) {
       vizion.update({
         folder: targetApp.cwd
-      }, function (err, meta) {
-        if (err) return callback(err);
-        console.log('[%s] Successfuly pulled application %s', new Date().toISOString(), targetName);
-        return callback();
-      });
+      }, logCallback(cb, '[%s] Successfuly pulled application %s', new Date().toISOString(), targetName));
     },
-    // Pre-hook
-    function (callback) {
-      if (!targetApp.prehook) return callback();
+    preHook: function preHook(cb) {
+      if (!targetApp.prehook) return cb();
 
-      exec(targetApp.prehook, execOptions, function (err, stdout, stderr) {
-        if (err) return callback(err);
-
-        console.log('[%s] Pre-hook command has been successfuly executed for app %s', new Date().toISOString(), targetName);
-        return callback();
-      });
+      exec(targetApp.prehook, execOptions,
+          logCallback(cb, '[%s] Pre-hook command has been successfuly executed for app %s', new Date().toISOString(), targetName));
     },
-    // Reload the application
-    function (callback) {
-      // if no pm2 is provided, we don't reload
-      if (targetApp.nopm2) return callback();
+    reloadApplication: function reloadApplication(cb) {
+      if (!targetApp.prehook) return cb();
 
-      pm2.gracefulReload(targetName, function (err, data) {
-        if (err) return callback(err);
-        console.log('[%s] Successfuly reloaded application %s', new Date().toISOString(), targetName);
-        return callback();
-      });
+      exec(targetApp.prehook, execOptions,
+          logCallback(cb, '[%s] Pre-hook command has been successfuly executed for app %s', new Date().toISOString(), targetName));
     },
-    // Post-hook
-    function (callback) {
-      if (!targetApp.posthook) return callback();
+    postHook: function postHook(cb) {
+      if (!targetApp.posthook) return cb();
 
       // execute the actual command in the cwd of the application
-      exec(targetApp.posthook, execOptions, function (err, stdout, stderr) {
-        if (err) return callback(err);
-
-        console.log('[%s] Posthook command has been successfuly executed for app %s', new Date().toISOString(), targetName);
-        return callback();
-      });
+      exec(targetApp.posthook, execOptions,
+          logCallback(cb, '[%s] Posthook command has been successfuly executed for app %s', new Date().toISOString(), targetName));
     }
+  };
+  async.series([
+	  steps.resolveCWD, steps.pullTheApplication, steps.preHook, steps.reloadApplication, steps.postHook
   ], function (err, results) {
     if (err) {
       console.log('[%s] An error has occuring while processing app %s', new Date().toISOString(), targetName);
@@ -229,10 +160,141 @@ Worker.prototype.processRequest = function (req) {
   });
 };
 
-// Lets start our server
+/**
+ * Checks if a request is valid for an app.
+ *
+ * @param targetApp The app which the request has to be valid
+ * @param req The request to analyze
+ * @returns {string|true} True if success or the string of the error if not.
+ */
+Worker.prototype.checkRequest = function checkRequest(targetApp, req) {
+	var targetName = reqToAppName(req);
+	switch (targetApp.service) {
+		case 'gitlab': {
+			if (!req.headers['x-gitlab-token']) {
+				return util.format('[%s] Received invalid request for app %s (no headers found)', new Date().toISOString(), targetName);
+			}
+
+			if (req.headers['x-gitlab-token'] !== targetApp.secret) {
+				return util.format('[%s] Received invalid request for app %s (not matching secret)', new Date().toISOString(), targetName);
+			}
+			break;
+		}
+		case 'jenkins': {
+			// ip must match the secret
+			if (req.ip.indexOf(targetApp.secret) < 0) {
+				return util.format('[%s] Received request from %s for app %s but ip configured was %s', new Date().toISOString(), req.ip, targetName, targetApp.secret);
+			}
+
+			var body = JSON.parse(req.body);
+			if (body.build.status !== 'SUCCESS') {
+				return util.format('[%s] Received valid hook but with failure build for app %s', new Date().toISOString(), targetName);
+			}
+			if (targetApp.branch && body.build.scm.branch.indexOf(targetApp.branch) < 0) {
+				return util.format('[%s] Received valid hook but with a branch %s than configured for app %s', new Date().toISOString(), body.build.scm.branch, targetName);
+			}
+			break;
+		}
+		case 'droneci': {
+			// Authorization header must match configured secret
+			if (!req.headers['Authorization']) {
+				return util.format('[%s] Received invalid request for app %s (no headers found)', new Date().toISOString(), targetName);
+			}
+			if (req.headers['Authorization'] !== targetApp.secret) {
+				return util.format('[%s] Received request from %s for app %s but incorrect secret', new Date().toISOString(), req.ip, targetName);
+			}
+
+			var data = JSON.parse(req.body);
+			if (data.build.status !== 'SUCCESS') {
+				return util.format('[%s] Received valid hook but with failure build for app %s', new Date().toISOString(), targetName);
+			}
+			if (targetApp.branch && data.build.branch.indexOf(targetApp.branch) < 0) {
+				return util.format('[%s] Received valid hook but with a branch %s than configured for app %s', new Date().toISOString(), data.build.branch, targetName);
+			}
+			break;
+		}
+		case 'bitbucket': {
+			var tmp = JSON.parse(req.body);
+			var ip = targetApp.secret || '104.192.143.0/24';
+			var configured = ipaddr.parseCIDR(ip);
+
+			if (!tmp.match(configured)) {
+				return util.format('[%s] Received request from %s for app %s but ip configured was %s', new Date().toISOString(), req.ip, targetName, ip);
+			}
+			if (!body.push) {
+				return util.format("[%s] Received valid hook but without 'push' data for app %s", new Date().toISOString(), targetName);
+			}
+			if (targetApp.branch && tmp.push.changes[0] && tmp.push.changes[0].new.name.indexOf(targetApp.branch) < 0) {
+				return util.format('[%s] Received valid hook but with a branch %s than configured for app %s', new Date().toISOString(), tmp.push.changes[0].new.name, targetName);
+			}
+			break;
+		}
+		case 'github' :
+		default: {
+			if (!req.headers['x-github-event'] || !req.headers['x-hub-signature']) {
+				return util.format('[%s] Received invalid request for app %s (no headers found)', new Date().toISOString(), targetName);
+			}
+
+			// compute hash of body with secret, github should send this to verify authenticity
+			var temp = crypto.createHmac('sha1', targetApp.secret);
+			temp.update(req.body, 'utf-8');
+			var hash = temp.digest('hex');
+
+			if ('sha1=' + hash !== req.headers['x-hub-signature']) {
+				return util.format('[%s] Received invalid request for app %s', new Date().toISOString(), targetName);
+			}
+			break;
+		}
+	}
+	return false;
+};
+
+/**
+ * Lets start our server
+ */
 Worker.prototype.start = function () {
   var self = this;
   this.server.listen(this.opts.port, function () {
     console.log('Server is ready and listen on port %s', self.opts.port);
   });
 };
+
+/**
+ * Executes the callback, but in case of success shows a message.
+ * Also accepts extra arguments to pass to console.log.
+ *
+ * Example:
+ * logCallback(next, '% worked perfect', appName)
+ *
+ * @param {Function} cb The callback to be called
+ * @param {string} message The message to show if success
+ * @returns {Function} The callback wrapped
+ */
+function logCallback(cb, message) {
+	var wrappedArgs = arguments;
+	return function (err, data) {
+		if (err) return cb(err);
+
+		wrappedArgs.shift();
+		console.log.apply(console, wrappedArgs);
+		cb(data);
+	}
+}
+
+/**
+ * Given a request, returns the name of the target App.
+ *
+ * Example:
+ * Call to 34.23.34.54:3000/api-2
+ * Will return 'api-2'
+ *
+ * @param req The request to be analysed
+ * @returns {string|null} The name of the app, or null if not found.
+ */
+function reqToAppName(req) {
+	var targetName = null;
+	try {
+		targetName = req.url.split('/').pop();
+	}
+	return targetName || null;
+}

--- a/index.js
+++ b/index.js
@@ -140,8 +140,8 @@ Worker.prototype.processRequest = function (req) {
     reloadApplication: function reloadApplication(cb) {
       if (!targetApp.nopm2) return cb();
 
-		pm2.gracefulReload(targetName,
-          logCallback(cb, '[%s] Successfuly reloaded application %s', new Date().toISOString(), targetName));
+      pm2.gracefulReload(targetName,
+	    logCallback(cb, '[%s] Successfuly reloaded application %s', new Date().toISOString(), targetName));
     },
     postHook: function postHook(cb) {
       if (!targetApp.posthook) return cb();

--- a/index.js
+++ b/index.js
@@ -158,6 +158,10 @@ Worker.prototype.processRequest = function (req) {
 
   console.log('[%s] Received valid hook for app %s', new Date().toISOString(), targetName);
 
+  var execOptions = {
+    cwd: targetApp.cwd,
+    maxBuffer: 1024 * 500
+  };
   async.series([
     // resolving cwd
     function (callback) {
@@ -187,7 +191,7 @@ Worker.prototype.processRequest = function (req) {
     function (callback) {
       if (!targetApp.prehook) return callback();
 
-      exec(targetApp.prehook, { cwd: targetApp.cwd }, function (err, stdout, stderr) {
+      exec(targetApp.prehook, execOptions, function (err, stdout, stderr) {
         if (err) return callback(err);
 
         console.log('[%s] Pre-hook command has been successfuly executed for app %s', new Date().toISOString(), targetName);
@@ -210,7 +214,7 @@ Worker.prototype.processRequest = function (req) {
       if (!targetApp.posthook) return callback();
 
       // execute the actual command in the cwd of the application
-      exec(targetApp.posthook, { cwd: targetApp.cwd }, function (err, stdout, stderr) {
+      exec(targetApp.posthook, execOptions, function (err, stdout, stderr) {
         if (err) return callback(err);
 
         console.log('[%s] Posthook command has been successfuly executed for app %s', new Date().toISOString(), targetName);

--- a/index.js
+++ b/index.js
@@ -97,7 +97,6 @@ Worker.prototype.processRequest = function (req) {
   if (targetName.length === 0) return;
 
   var targetApp = this.apps[targetName];
-  console.log('t', this.apps);
   if (!targetApp) return;
 
   var error = this.checkRequest(targetApp, req);
@@ -120,12 +119,7 @@ Worker.prototype.processRequest = function (req) {
 
       // try to get the cwd to execute it correctly
       pm2.describe(targetName, function (err, apps) {
-        apps = [
-            {
-              pm_cwd: '/home/desaroger'
-            }
-        ];
-        // if (err || !apps || apps.length === 0) return cb(err || new Error('Application not found'));
+        if (err || !apps || apps.length === 0) return cb(err || new Error('Application not found'));
 
         // execute the actual command in the cwd of the application
         targetApp.cwd = apps[0].pm_cwd ? apps[0].pm_cwd : apps[0].pm2_env.pm_cwd;

--- a/index.js
+++ b/index.js
@@ -140,7 +140,7 @@ Worker.prototype.processRequest = function (req) {
     reloadApplication: function reloadApplication(cb) {
       if (!targetApp.nopm2) return cb();
 
-      spawnAsExec(targetApp.prehook, execOptions,
+		pm2.gracefulReload(targetName,
           logCallback(cb, '[%s] Successfuly reloaded application %s', new Date().toISOString(), targetName));
     },
     postHook: function postHook(cb) {


### PR DESCRIPTION
This is my first approach to replace the usage of `exec` and use `spawn` instead.

Also I refactored a little, adding jsdocs to the main functions, extracting the checks of the request to another function (`checkRequest`), and creating a helper object (I called it 'phases') where the different phases are (I think) more clear.

Unlike `exec`, which accepts a full line command (like 'npm run test && npm start'), `spawn` needs a main command and an array of arguments. My approach to this is to run always the command 'eval', and as first argument I pass the line specified in prehook and posthook. It needs to be a best option, but I was struggle with it investigating on internet and I could not find a solution.
