### PR TITLE
fix empty req body and broken bitbucket

### DIFF
--- a/index.js
+++ b/index.js
@@ -142,7 +142,7 @@ Worker.prototype.processRequest = function (req) {
           logCallback(cb, '[%s] Prehook command has been successfuly executed for app %s', new Date().toISOString(), targetName));
     },
     reloadApplication: function reloadApplication(cb) {
-      if (!targetApp.nopm2) return cb();
+      if (targetApp.nopm2) return cb();
 
       pm2.gracefulReload(targetName,
 	    logCallback(cb, '[%s] Successfuly reloaded application %s', new Date().toISOString(), targetName));
@@ -282,7 +282,7 @@ function logCallback(cb, message) {
 
     wrappedArgs.shift();
     console.log.apply(console, wrappedArgs);
-    cb(data);
+    cb();
   }
 }
 


### PR DESCRIPTION
Hello @vmarchaud,

using nodejs v0.12.6 on a raspberry pi, the request body is empty if the response is closed before the "data"-event is registered. Calling res.end() only after req.on("data") fixes the problem.
Also, the bitbucket part broke during some refacturing and should work again with this commit applied.

Cheers,
Martin